### PR TITLE
Fix bookmarks with id greater than nine not being shown

### DIFF
--- a/web/ideabag2-web/src/views/Bookmarks.vue
+++ b/web/ideabag2-web/src/views/Bookmarks.vue
@@ -29,7 +29,7 @@ export default {
   },
   watch: {
     userDataDB(db) {
-      if (db !== undefined) {
+      if (db !== null) {
         this.loadIdeas();
       }
     }
@@ -46,15 +46,15 @@ export default {
       }
     },
     loadIdea(id) {
-      const categoryId = id[0];
-      const ideaId = id[3] - 1;
+      const categoryId = id.split("C")[0];
+      const ideaId = id.split("-")[1].split("I")[0] - 1;
       this.ideas.push(this.$store.getters.categories[categoryId].items[ideaId]);
     }
   },
   components: { IdeaList },
   activated() {
     this.$store.dispatch('setTitle', "Bookmarks");
-    if (this.userDataDB !== undefined) {
+    if (this.userDataDB !== null) {
       this.loadIdeas();
     }
   }

--- a/web/ideabag2-web/src/views/IdeaDetail.vue
+++ b/web/ideabag2-web/src/views/IdeaDetail.vue
@@ -107,7 +107,7 @@ export default {
 	},
 	watch: {
 		userDataDB(db) {
-			if (db !== undefined) {
+			if (db !== null) {
 				this.loadUserData();
 			}
 		}
@@ -121,7 +121,7 @@ export default {
 
 		this.idea = this.$store.getters.categories[categoryIndex].items[ideaIndex];
 
-		if (this.userDataDB !== undefined) {
+		if (this.userDataDB !== null) {
 			this.loadUserData();
 		}
 


### PR DESCRIPTION
I fixed a bug that caused bookmarks with an id greater than 9 to not be shown on the bookmarks page.